### PR TITLE
reopen Ember.Router instead of Ember.Route

### DIFF
--- a/addon/initializers/route-perf.js
+++ b/addon/initializers/route-perf.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import RoutePerf from 'ember-performance-tracking/mixins/route-perf';
 
 export function initialize() {
-  Ember.Route.reopen(RoutePerf);
+  Ember.Router.reopen(RoutePerf);
 }
 
 export default {

--- a/addon/mixins/route-perf.js
+++ b/addon/mixins/route-perf.js
@@ -2,20 +2,17 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   perfTracking: Ember.inject.service('performance-tracking'),
-  actions: {
-    /**
-     * Schedule a function to call the endTransition function of the perfTracking service in afterRender run queue
-     */
-    didTransition: function() {
-      var self = this;
-      Ember.run.scheduleOnce('afterRender', function () {
-        self.get('perfTracking').endTransition(self.routeName, self.get('router.url'));
-      });
-      return this._super.apply(this, arguments);
-    },
-    willTransition: function() {
-      this.get('perfTracking').startTransition();
-      return this._super.apply(this, arguments);
-    }
+  /**
+   * Schedule a function to call the endTransition function of the perfTracking service in afterRender run queue
+   */
+  didTransition: function() {
+    Ember.run.scheduleOnce('afterRender', () => {
+      this.get('perfTracking').endTransition(this.get('currentRouteName'), this.get('currentURL'));
+    });
+    return this._super(...arguments);
+  },
+  willTransition: function() {
+    this.get('perfTracking').startTransition();
+    return this._super(...arguments);
   }
 });


### PR DESCRIPTION
If a route doesn't call `_super` or `return true` then `didTransition` and `willTransition` for `Ember.Route` will not trigger. However, `Ember.Router` will trigger regardless.